### PR TITLE
When event emitter closes, should clean up old files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,41 +1,63 @@
 {
-    "name" : "git-emit",
-    "description" : "expose git hooks through an event emitter",
-    "version" : "0.0.0",
-    "repository" : {
-        "type" : "git",
-        "url" : "git://github.com/substack/node-git-emit.git"
-    },
-    "main" : "index.js",
-    "keywords" : [
-        "git",
-        "hook",
-        "emit",
-        "repository"
-    ],
-    "directories" : {
-        "lib" : ".",
-        "example" : "example",
-        "test" : "test"
-    },
-    "scripts" : {
-        "test" : "tap test/*.js"
-    },
-    "dependencies" : {
-        "seq" : "0.3.x",
-        "dnode" : "0.9.x"
-    },
-    "devDependencies" : {
-        "tap" : "0.0.x",
-        "pushover" : "0.0.x"
-    },
-    "engines" : {
-        "node" : ">=0.4.0"
-    },
-    "license" : "MIT",
-    "author" : {
-        "name" : "James Halliday",
-        "email" : "mail@substack.net",
-        "url" : "http://substack.net"
+  "name": "git-emit",
+  "description": "expose git hooks through an event emitter",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/substack/node-git-emit.git"
+  },
+  "main": "index.js",
+  "keywords": [
+    "git",
+    "hook",
+    "emit",
+    "repository"
+  ],
+  "directories": {
+    "lib": ".",
+    "example": "example",
+    "test": "test"
+  },
+  "scripts": {
+    "test": "tap test/*.js"
+  },
+  "dependencies": {
+    "seq": "0.3.x",
+    "dnode": "0.9.x"
+  },
+  "devDependencies": {
+    "tap": "0.7.x",
+    "pushover": "0.0.x"
+  },
+  "engines": {
+    "node": ">=0.4.0"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net"
+  },
+  "_npmUser": {
+    "name": "substack",
+    "email": "mail@substack.net"
+  },
+  "_id": "git-emit@0.0.0",
+  "_engineSupported": true,
+  "_npmVersion": "1.0.106",
+  "_nodeVersion": "v0.4.12",
+  "_defaultsLoaded": true,
+  "dist": {
+    "shasum": "41a8162fab4b2353df73af22d2e802ae0bb0e7c3",
+    "tarball": "http://registry.npmjs.org/git-emit/-/git-emit-0.0.0.tgz"
+  },
+  "maintainers": [
+    {
+      "name": "substack",
+      "email": "mail@substack.net"
     }
+  ],
+  "_shasum": "41a8162fab4b2353df73af22d2e802ae0bb0e7c3",
+  "_resolved": "https://registry.npmjs.org/git-emit/-/git-emit-0.0.0.tgz",
+  "_from": "git-emit@*"
 }

--- a/package.json
+++ b/package.json
@@ -1,63 +1,41 @@
 {
-  "name": "git-emit",
-  "description": "expose git hooks through an event emitter",
-  "version": "0.0.0",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/substack/node-git-emit.git"
-  },
-  "main": "index.js",
-  "keywords": [
-    "git",
-    "hook",
-    "emit",
-    "repository"
-  ],
-  "directories": {
-    "lib": ".",
-    "example": "example",
-    "test": "test"
-  },
-  "scripts": {
-    "test": "tap test/*.js"
-  },
-  "dependencies": {
-    "seq": "0.3.x",
-    "dnode": "0.9.x"
-  },
-  "devDependencies": {
-    "tap": "0.7.x",
-    "pushover": "0.0.x"
-  },
-  "engines": {
-    "node": ">=0.4.0"
-  },
-  "license": "MIT",
-  "author": {
-    "name": "James Halliday",
-    "email": "mail@substack.net",
-    "url": "http://substack.net"
-  },
-  "_npmUser": {
-    "name": "substack",
-    "email": "mail@substack.net"
-  },
-  "_id": "git-emit@0.0.0",
-  "_engineSupported": true,
-  "_npmVersion": "1.0.106",
-  "_nodeVersion": "v0.4.12",
-  "_defaultsLoaded": true,
-  "dist": {
-    "shasum": "41a8162fab4b2353df73af22d2e802ae0bb0e7c3",
-    "tarball": "http://registry.npmjs.org/git-emit/-/git-emit-0.0.0.tgz"
-  },
-  "maintainers": [
-    {
-      "name": "substack",
-      "email": "mail@substack.net"
+    "name" : "git-emit",
+    "description" : "expose git hooks through an event emitter",
+    "version" : "0.0.0",
+    "repository" : {
+        "type" : "git",
+        "url" : "git://github.com/substack/node-git-emit.git"
+    },
+    "main" : "index.js",
+    "keywords" : [
+        "git",
+        "hook",
+        "emit",
+        "repository"
+    ],
+    "directories" : {
+        "lib" : ".",
+        "example" : "example",
+        "test" : "test"
+    },
+    "scripts" : {
+        "test" : "tap test/*.js"
+    },
+    "dependencies" : {
+        "seq" : "0.3.x",
+        "dnode" : "0.9.x"
+    },
+    "devDependencies" : {
+        "tap" : "0.7.x",
+        "pushover" : "0.0.x"
+    },
+    "engines" : {
+        "node" : ">=0.4.0"
+    },
+    "license" : "MIT",
+    "author" : {
+        "name" : "James Halliday",
+        "email" : "mail@substack.net",
+        "url" : "http://substack.net"
     }
-  ],
-  "_shasum": "41a8162fab4b2353df73af22d2e802ae0bb0e7c3",
-  "_resolved": "https://registry.npmjs.org/git-emit/-/git-emit-0.0.0.tgz",
-  "_from": "git-emit@*"
 }

--- a/test/accept.js
+++ b/test/accept.js
@@ -10,22 +10,22 @@ var seq = require('seq');
 
 test('accept a patch', function (t) {
     t.plan(3);
-    
+
     var repoDir = '/tmp/' + Math.floor(Math.random() * (1<<30)).toString(16);
     var srcDir = '/tmp/' + Math.floor(Math.random() * (1<<30)).toString(16);
     var dstDir = '/tmp/' + Math.floor(Math.random() * (1<<30)).toString(16);
-    
+
     fs.mkdirSync(repoDir, 0700);
     fs.mkdirSync(srcDir, 0700);
     fs.mkdirSync(dstDir, 0700);
-    
+
     var port = Math.floor(Math.random() * ((1<<16) - 1e4)) + 1e4;
     var repos = pushover(repoDir, this.ok)
     repos.on('push', function (repo) {
         t.equal(repo, 'doom');
     });
     var server = repos.listen(port);
-    
+
     process.chdir(srcDir);
     var repoEmitter;
     seq()
@@ -64,7 +64,7 @@ test('accept a patch', function (t) {
                 .on('exit', this.ok)
         })
         .seq_(function (next) {
-            path.exists(dstDir + '/doom/a.txt', function (ex) {
+            fs.exists(dstDir + '/doom/a.txt', function (ex) {
                 t.ok(ex, 'a.txt exists');
                 next();
             })

--- a/test/reject.js
+++ b/test/reject.js
@@ -10,22 +10,22 @@ var seq = require('seq');
 
 test('reject a patch', function (t) {
     t.plan(3);
-    
+
     var repoDir = '/tmp/' + Math.floor(Math.random() * (1<<30)).toString(16);
     var srcDir = '/tmp/' + Math.floor(Math.random() * (1<<30)).toString(16);
     var dstDir = '/tmp/' + Math.floor(Math.random() * (1<<30)).toString(16);
-    
+
     fs.mkdirSync(repoDir, 0700);
     fs.mkdirSync(srcDir, 0700);
     fs.mkdirSync(dstDir, 0700);
-    
+
     var port = Math.floor(Math.random() * ((1<<16) - 1e4)) + 1e4;
     var repos = pushover(repoDir, this.ok)
     repos.on('push', function (repo) {
         t.equal(repo, 'doom');
     });
     var server = repos.listen(port);
-    
+
     process.chdir(srcDir);
     var repoEmitter;
     seq()
@@ -64,7 +64,7 @@ test('reject a patch', function (t) {
                 .on('exit', this.ok)
         })
         .seq_(function (next) {
-            path.exists(dstDir + '/doom/a.txt', function (ex) {
+            fs.exists(dstDir + '/doom/a.txt', function (ex) {
                 t.ok(!ex, 'a.txt should not exist');
                 next();
             })


### PR DESCRIPTION
Simple change, I chose to do it synchronously so that before the process exits we can delete all the files as well. This can also be implemented async however for now I don't think it matters.

Btw, very sweet module. If this is deprecated (considering it was done in 2011 and still is compatible with node 0.4.x O_O) Let me know!