### PR TITLE
update dnode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     },
     "dependencies" : {
         "seq" : "0.3.x",
-        "dnode" : "0.9.x"
+        "dnode" : "1.2.2"
     },
     "devDependencies" : {
-        "tap" : "0.0.x",
+        "tap" : "10.3.x",
         "pushover" : "0.0.x"
     },
     "engines" : {

--- a/test/accept.js
+++ b/test/accept.js
@@ -64,7 +64,8 @@ test('accept a patch', function (t) {
                 .on('exit', this.ok)
         })
         .seq_(function (next) {
-            path.exists(dstDir + '/doom/a.txt', function (ex) {
+            fs.open(dstDir + '/doom/a.txt','r',function(err){
+                var ex = err ? (err.code === "ENOENT" ? false : true) :true;
                 t.ok(ex, 'a.txt exists');
                 next();
             })

--- a/test/reject.js
+++ b/test/reject.js
@@ -64,10 +64,11 @@ test('reject a patch', function (t) {
                 .on('exit', this.ok)
         })
         .seq_(function (next) {
-            path.exists(dstDir + '/doom/a.txt', function (ex) {
+            fs.open(dstDir + '/doom/a.txt','r',function(err){
+                var ex = err ? (err.code === "ENOENT" ? false : true) :true;
                 t.ok(!ex, 'a.txt should not exist');
                 next();
-            })
+            });
         })
         .seq(function () {
             server.close();


### PR DESCRIPTION
update dnode to 1.2.2
update tap to 10.3.0
updated tests to work with newer nodejs

dnode 0.9.x does not work on new versions of node
    -> uses an old version of **socket.io** that is not compatible
       with new versions of Node
       (**EventEmitter.prototype** is undefined
       -> it was taken from the **process** global variable)
tap 0.0.14
    -> newer utils.inherits does not set Super-class

after these changes the tests still pass.


I made these changes because I wanted to fix a bug in NodeJS-Git-Server.